### PR TITLE
Add CloudEvent JSON serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Note that the `CloudEvents\Client` implements the [PSR-18](https://www.php-fig.o
 ## Serialize/Deserialize a CloudEvent
 
 ```php
+use CloudEvents\Serializers\JsonSerializer;
 use \CloudEvents\V1\CloudEvent;
 
 $event = (new CloudEvent())
@@ -49,10 +50,11 @@ $event = (new CloudEvent())
     ->setType('com.example.type')
     ->setData(json_encode(['example' => 'first-event']));
 
-// via class methods
-$serializedEvent = $event->toJson(); // or Event::toJson($event);
-$deserializedEvent = Event::fromJson($serializedEvent);
+// JSON serialization
+$serializer = new JsonSerializer();
+$serializer->serialize($event);
 
+// TODO: deserilization
 ```
 
 ## Community

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         }
     },
     "require": {
-        "php": ">=7.4"
+        "php": ">=7.4",
+        "ext-json": "*"
     },
     "require-dev": {
         "nunomaduro/collision": "^5.2",

--- a/src/CloudEvents/Serializers/Exceptions/SerializationException.php
+++ b/src/CloudEvents/Serializers/Exceptions/SerializationException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace CloudEvents\Serializers\Exceptions;
+
+use Exception;
+
+abstract class SerializationException extends Exception
+{
+
+}

--- a/src/CloudEvents/Serializers/Exceptions/UnsupportedEventSpecVersionException.php
+++ b/src/CloudEvents/Serializers/Exceptions/UnsupportedEventSpecVersionException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace CloudEvents\Serializers\Exceptions;
+
+use Throwable;
+
+class UnsupportedEventSpecVersionException extends SerializationException
+{
+    public function __construct(
+        $message = 'Unsupported CloudEvent spec version.',
+        $code = 0,
+        Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/CloudEvents/Serializers/JsonSerializer.php
+++ b/src/CloudEvents/Serializers/JsonSerializer.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace CloudEvents\Serializers;
+
+use CloudEvents\CloudEventInterface;
+use CloudEvents\Serializers\Exceptions\UnsupportedEventSpecVersionException;
+use CloudEvents\V1\CloudEventInterface as V1CloudEventInterface;
+use DateTimeInterface;
+
+use function array_merge;
+
+class JsonSerializer
+{
+    /**
+     * @throws UnsupportedEventSpecVersionException
+     * @throws \JsonException
+     */
+    public function serialize(CloudEventInterface $cloudEvent): string
+    {
+        $payload = $this->createPayload($cloudEvent);
+        $payload = array_merge($payload, $this->formatData($cloudEvent->getData()));
+
+        return json_encode($payload, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Get a JSON-serializable array representation of the CloudEvent.
+     *
+     * @throws UnsupportedEventSpecVersionException
+     */
+    protected function createPayload(CloudEventInterface $cloudEvent): array
+    {
+        if ($cloudEvent instanceof V1CloudEventInterface) {
+            return [
+                'specversion' => $cloudEvent->getSpecVersion(),
+                'id' => $cloudEvent->getId(),
+                'type' => $cloudEvent->getType(),
+                'datacontenttype' => $cloudEvent->getDataContentType(),
+                'dataschema' => $cloudEvent->getDataSchema(),
+                'subject' => $cloudEvent->getSubject(),
+                'time' => $this->formatTime($cloudEvent->getTime()),
+            ];
+        }
+
+        throw new UnsupportedEventSpecVersionException();
+    }
+
+    private function formatTime(?DateTimeInterface $time): ?string
+    {
+        return $time === null ? null : $time->format(DATE_RFC3339);
+    }
+
+    /**
+     * @param mixed|null $data
+     */
+    private function formatData($data): array
+    {
+        if ($this->isBinary($data)) {
+            return ['data_base64' => base64_encode($data)];
+        }
+
+        return ['data' => $data];
+    }
+
+    /**
+     * @param mixed|null $data
+     */
+    private function isBinary($data): bool
+    {
+        return is_string($data) && !preg_match('//u', $data);
+    }
+}

--- a/src/CloudEvents/V1/CloudEvent.php
+++ b/src/CloudEvents/V1/CloudEvent.php
@@ -8,8 +8,6 @@ use DateTimeInterface;
 
 class CloudEvent implements CloudEventInterface
 {
-    private const SPEC_VERSION = '1.0';
-
     private string $id;
     private string $source;
     private string $type;

--- a/src/CloudEvents/V1/CloudEventInterface.php
+++ b/src/CloudEvents/V1/CloudEventInterface.php
@@ -6,6 +6,8 @@ namespace CloudEvents\V1;
 
 interface CloudEventInterface extends \CloudEvents\CloudEventInterface
 {
+    public const SPEC_VERSION = '1.0';
+
     public function getId(): string;
 
     public function getSource(): string;

--- a/tests/CloudEvents/Serializers/JsonSerializerTest.php
+++ b/tests/CloudEvents/Serializers/JsonSerializerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace CloudEvents\Tests\CloudEvents\Serializers;
+
+use CloudEvents\Serializers\JsonSerializer;
+use CloudEvents\V1\CloudEventInterface;
+use DateTimeImmutable;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \CloudEvents\Serializers\JsonSerializer
+ */
+class JsonSerializerTest extends TestCase
+{
+    /**
+     * @covers ::serialize
+     */
+    public function testSerialize(): void
+    {
+        /** @var CloudEventInterface|Stub $event */
+        $event = $this->createStub(CloudEventInterface::class);
+        $event->method('getSpecVersion')->willReturn('1.0');
+        $event->method('getId')->willReturn('1234-1234-1234');
+        $event->method('getType')->willReturn('com.example.someevent');
+        $event->method('getDataContentType')->willReturn('application/json');
+        $event->method('getDataSchema')->willReturn('com.example/schema');
+        $event->method('getSubject')->willReturn('larger-context');
+        $event->method('getTime')->willReturn(new DateTimeImmutable('2018-04-05T17:31:00Z'));
+        $event->method('getData')->willReturn(['key' => 'value']);
+
+        $formatter = new JsonSerializer();
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode(
+                [
+                    'specversion' => '1.0',
+                    'id' => '1234-1234-1234',
+                    'type' => 'com.example.someevent',
+                    'datacontenttype' => 'application/json',
+                    'dataschema' => 'com.example/schema',
+                    'subject' => 'larger-context',
+                    'time' => '2018-04-05T17:31:00+00:00',
+                    'data' => [
+                        'key' => 'value',
+                    ]
+                ],
+                JSON_THROW_ON_ERROR
+            ),
+            $formatter->serialize($event)
+        );
+    }
+}


### PR DESCRIPTION
This adds a new JSON serializer class to transform a CloudEvent instance to a JSON string. My first go-around had V1 with its own serializer, but I think the implication would have been a serializer factory of some sort, which didn't seem too efficient. This seems more straightforward.

I added the JSON serialization options bit mask to enable some formatting flags. The spec says optional fields with `null` values MAY be dropped, so a flag seemed like an easy way to do that.