### PR TITLE
build: add local testing envs for PHP 7.4 + 8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ composer.lock
 phpcs.xml
 phpunit.xml
 
+coverage
 vendor

--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ $deserializedEvent = Event::fromJson($serializedEvent);
 
 ```
 
+## Testing
+
+You can use `composer` to build and run test environments when contributing.
+
+```
+$ composer run -l
+
+scripts:
+  lint          Show all current linting errors according to PSR12
+  lint-fix      Show and fix all current linting errors according to PSR12
+  tests         Run all tests locally
+  tests-build   Build containers to test against supported PHP versions
+  tests-docker  Run tests within supported PHP version containers
+```
+
 ## Community
 
 - There are bi-weekly calls immediately following the [Serverless/CloudEvents

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,22 @@
     "scripts": {
         "lint": "./vendor/bin/phpcs --standard=PSR12 ./src ./tests",
         "lint-fix": "./vendor/bin/phpcbf --standard=PSR12 ./src ./tests",
-        "tests": "./vendor/bin/phpunit"
+        "tests": "./vendor/bin/phpunit",
+        "tests-build": [
+            "DOCKER_BUILDKIT=1 docker build -t cloudevents/sdk-php:7.4-tests -f hack/7.4.Dockerfile hack",
+            "DOCKER_BUILDKIT=1 docker build -t cloudevents/sdk-php:8.0-tests -f hack/8.0.Dockerfile hack"
+        ],
+        "tests-docker": [
+            "docker run -it -v $(pwd):/var/www cloudevents/sdk-php:7.4-tests --coverage-html=coverage",
+            "docker run -it -v $(pwd):/var/www cloudevents/sdk-php:8.0-tests"
+        ]
+    },
+    "scripts-descriptions": {
+        "lint": "Show all current linting errors according to PSR12",
+        "lint-fix": "Show and fix all current linting errors according to PSR12",
+        "tests": "Run all tests locally",
+        "tests-build": "Build containers to test against supported PHP versions",
+        "tests-docker": "Run tests within supported PHP version containers"
     },
     "config": {
         "sort-packages": true

--- a/hack/7.4.Dockerfile
+++ b/hack/7.4.Dockerfile
@@ -1,0 +1,26 @@
+FROM php:7.4-alpine
+
+LABEL org.opencontainers.image.url="https://github.com/cloudevents/sdk-php/tree/master/hack/7.4.Dockerfile" \
+      org.opencontainers.image.documentation="https://github.com/cloudevents/sdk-php/tree/master/hack/README.md" \
+      org.opencontainers.image.source="https://github.com/cloudevents/sdk-php" \
+      org.opencontainers.image.vendor="CloudEvent" \
+      org.opencontainers.image.title="PHP 7.4" \
+      org.opencontainers.image.description="PHP 7.4 test environment for cloudevents/sdk-php"
+
+COPY --chown=www-data:www-data install-composer /usr/local/bin/install-composer
+RUN chmod +x /usr/local/bin/install-composer \
+    && /usr/local/bin/install-composer \
+    && rm /usr/local/bin/install-composer
+
+RUN apk update \
+    && apk --no-cache upgrade \
+    && apk add --no-cache bash ca-certificates git libzip-dev \
+    && apk add --no-cache --virtual build-deps autoconf build-base g++ \
+    && pecl install pcov \
+    && docker-php-ext-enable pcov \
+    && apk del --purge build-deps \
+    && rm -rf /var/www/html /tmp/pear \
+    && chown -R www-data:www-data /var/www
+
+WORKDIR /var/www
+ENTRYPOINT ["/var/www/vendor/bin/phpunit"]

--- a/hack/8.0.Dockerfile
+++ b/hack/8.0.Dockerfile
@@ -1,0 +1,22 @@
+FROM php:8.0-alpine
+
+LABEL org.opencontainers.image.url="https://github.com/cloudevents/sdk-php/tree/master/hack/8.0.Dockerfile" \
+      org.opencontainers.image.documentation="https://github.com/cloudevents/sdk-php/tree/master/hack/README.md" \
+      org.opencontainers.image.source="https://github.com/cloudevents/sdk-php" \
+      org.opencontainers.image.vendor="CloudEvent" \
+      org.opencontainers.image.title="PHP 8.0" \
+      org.opencontainers.image.description="PHP 8.0 test environment for cloudevents/sdk-php"
+
+COPY --chown=www-data:www-data install-composer-2.0.8 /usr/local/bin/install-composer
+RUN chmod +x /usr/local/bin/install-composer \
+    && /usr/local/bin/install-composer \
+    && rm /usr/local/bin/install-composer
+
+RUN apk update \
+    && apk --no-cache upgrade \
+    && apk add --no-cache bash ca-certificates git libzip-dev \
+    && rm -rf /var/www/html /tmp/pear \
+    && chown -R www-data:www-data /var/www
+
+WORKDIR /var/www
+ENTRYPOINT ["/var/www/vendor/bin/phpunit"]

--- a/hack/install-composer
+++ b/hack/install-composer
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+EXPECTED_CHECKSUM="$(wget -q -O - https://composer.github.io/installer.sig)"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]
+then
+    >&2 echo 'ERROR: Invalid installer checksum'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --install-dir=/usr/local/bin --filename=composer --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT

--- a/hack/install-composer-2.0.8
+++ b/hack/install-composer-2.0.8
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+php -r "if (hash_file('sha384', 'composer-setup.php') === '756890a4488ce9024fc62c56153228907f1545c228516cbf63f885e036d37e9a59d27d63f46af1d4d07ee0f76181c7d3') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+php composer-setup.php --install-dir=/usr/local/bin --filename=composer --quiet
+php -r "unlink('composer-setup.php');" \


### PR DESCRIPTION
The image tags of `cloudevents/sdk-php:7.4-tests` are only meant for local development. They should probably be updated to a better naming convention eventually.

There was an issue with the checksum validation when installing composer via the [recommended script](https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md) on the `php:8.0-alpine` image, so we are currently installing the `2.0.8` release directly.

Code coverage doesn't need to be available or run for both versions of PHP, so it is only available on the 7.4 image.

cc: @rubenrangel 