### PR TITLE
Add a branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,5 +51,10 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
     }
 }


### PR DESCRIPTION
So that developers can use the version constraint `^1.0@dev` to get the current WIP version (and get stable 1.x tags once they exist), instead of other hacks.