### PR TITLE
prevent attributes with null value from encoding

### DIFF
--- a/src/CloudEvents/Serializers/ArraySerializer.php
+++ b/src/CloudEvents/Serializers/ArraySerializer.php
@@ -26,10 +26,10 @@ class ArraySerializer
      */
     public function serialize(CloudEventInterface $cloudEvent): array
     {
-        return array_merge(
+        return array_filter(array_merge(
             $this->encodePayload($cloudEvent),
             $this->formatter->encodeData($cloudEvent->getData())
-        );
+        ), fn ($attr) => $attr !== null);
     }
 
     /**

--- a/tests/CloudEvents/Serializers/ArraySerializerTest.php
+++ b/tests/CloudEvents/Serializers/ArraySerializerTest.php
@@ -51,6 +51,35 @@ class ArraySerializerTest extends TestCase
     }
 
     /**
+     * @covers ::serialize
+     */
+    public function testSerializeWithUnsetAttributes(): void
+    {
+        /** @var CloudEventInterface|Stub $event */
+        $event = $this->createStub(CloudEventInterface::class);
+        $event->method('getSpecVersion')->willReturn('1.0');
+        $event->method('getId')->willReturn('1234-1234-1234');
+        $event->method('getSource')->willReturn('/var/data');
+        $event->method('getType')->willReturn('com.example.someevent');
+        $event->method('getSubject')->willReturn('larger-context');
+        $event->method('getTime')->willReturn(new DateTimeImmutable('2018-04-05T17:31:00Z'));
+
+        $formatter = new ArraySerializer();
+
+        $this->assertSame(
+            [
+                'specversion' => '1.0',
+                'id' => '1234-1234-1234',
+                'source' => '/var/data',
+                'type' => 'com.example.someevent',
+                'subject' => 'larger-context',
+                'time' => '2018-04-05T17:31:00Z',
+            ],
+            $formatter->serialize($event)
+        );
+    }
+
+    /**
      * @covers ::deserialize
      */
     public function testDeserialize(): void


### PR DESCRIPTION
Type system does not allow for a null type, so we are defaulting to
remove attributes with a null value from the final encoding.
https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#type-system

Signed-off-by: John Laswell <john.n.laswell@gmail.com>