### PR TITLE
Fix Formatter:decodeTime() implementation

### DIFF
--- a/src/CloudEvents/Serializers/Formatters/Formatter.php
+++ b/src/CloudEvents/Serializers/Formatters/Formatter.php
@@ -27,11 +27,9 @@ class Formatter implements FormatterInterface
 
     public function decodeTime(?string $time): ?DateTimeInterface
     {
-        $parsed = DateTimeImmutable::createFromFormat(self::TIME_FORMAT, $time, new DateTimeZone(self::TIME_ZONE));
-
-        return $parsed === false
+        return $time === null
             ? null
-            : $parsed;
+            : DateTimeImmutable::createFromFormat(self::TIME_FORMAT, $time, new DateTimeZone(self::TIME_ZONE));
     }
 
     /**

--- a/src/CloudEvents/Serializers/Formatters/Formatter.php
+++ b/src/CloudEvents/Serializers/Formatters/Formatter.php
@@ -27,9 +27,19 @@ class Formatter implements FormatterInterface
 
     public function decodeTime(?string $time): ?DateTimeInterface
     {
-        return $time === null
-            ? null
-            : DateTimeImmutable::createFromFormat(self::TIME_FORMAT, $time, new DateTimeZone(self::TIME_ZONE));
+        if ($time === null) {
+            return null;
+        }
+
+        $decoded = DateTimeImmutable::createFromFormat(self::TIME_FORMAT, $time, new DateTimeZone(self::TIME_ZONE));
+
+        if ($decoded === false) {
+              throw new ValueError(
+                \sprintf('%s::decodeTime(): Argument #1 ($time) is not a valid RFC3339 timestamp', self::class)
+            );
+        }
+
+        return $decoded;
     }
 
     /**

--- a/tests/CloudEvents/Serializers/Formatters/FormatterTest.php
+++ b/tests/CloudEvents/Serializers/Formatters/FormatterTest.php
@@ -5,6 +5,7 @@ namespace CloudEvents\Tests\CloudEvents\Serializers\Formatters;
 use CloudEvents\Serializers\Formatters\Formatter;
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
+use ValueError;
 
 /**
  * @coversDefaultClass \CloudEvents\Serializers\Formmaters\Formatter
@@ -20,6 +21,17 @@ class FormatterTest extends TestCase
         $formatter = new Formatter();
         $this->assertEquals('2018-04-05T17:31:00Z', $formatter->encodeTime(new DateTimeImmutable('2018-04-05T17:31:00Z')));
         $this->assertEquals(new DateTimeImmutable('2018-04-05T17:31:00Z'), $formatter->decodeTime('2018-04-05T17:31:00Z'));
+    }
+
+    /**
+     * @covers ::decodeTime
+     */
+    public function testDecodeInvalidTime(): void
+    {
+        $formatter = new Formatter();
+        $this->expectException(ValueError::class);
+        $this->expectExceptionMessage('CloudEvents\\Serializers\\Formatters\\Formatter::decodeTime(): Argument #1 ($time) is not a valid RFC3339 timestamp');
+        $formatter->decodeTime('2018asdsdsafd');
     }
 
     /**


### PR DESCRIPTION
Reverts cloudevents/sdk-php#22. The old code was not broken. It was intentionally throwing a TypeError when you pass a bad timestamp string. We do not want to silently return null.