### PR TITLE
Added `getExtension` method to cloudevent v1 interface

### DIFF
--- a/src/CloudEvents/V1/CloudEvent.php
+++ b/src/CloudEvents/V1/CloudEvent.php
@@ -236,6 +236,14 @@ class CloudEvent implements CloudEventInterface
     }
 
     /**
+     * @return bool|int|string|null
+     */
+    public function getExtension(string $attribute)
+    {
+        return $this->extensions[$attribute] ?? null;
+    }
+
+    /**
      * @param array<string,bool|int|string|null> $extensions
      */
     public function setExtensions(array $extensions): CloudEvent

--- a/src/CloudEvents/V1/CloudEventInterface.php
+++ b/src/CloudEvents/V1/CloudEventInterface.php
@@ -33,4 +33,9 @@ interface CloudEventInterface extends \CloudEvents\CloudEventInterface
      * @return array<string,bool|int|string>
      */
     public function getExtensions(): array;
+
+    /**
+     * @return bool|int|string|null
+     */
+    public function getExtension(string $attribute);
 }

--- a/tests/CloudEvents/V1/CloudEventTest.php
+++ b/tests/CloudEvents/V1/CloudEventTest.php
@@ -172,11 +172,16 @@ class CloudEventTest extends TestCase
     {
         $event = $this->getEvent();
         $this->assertEquals([], $event->getExtensions());
+        $this->assertNull($event->getExtension('comacme'));
+        $this->assertNull($event->getExtension('comacme2'));
         $event->setExtension('comacme', 'foo');
+        $this->assertEquals('foo', $event->getExtension('comacme'));
         $this->assertEquals(['comacme' => 'foo'], $event->getExtensions());
         $event->setExtension('comacme2', 123);
+        $this->assertEquals(123, $event->getExtension('comacme2'));
         $this->assertEquals(['comacme' => 'foo', 'comacme2' => 123], $event->getExtensions());
         $event->setExtension('comacme', null);
+        $this->assertNull($event->getExtension('comacme'));
         $this->assertEquals(['comacme2' => 123], $event->getExtensions());
     }
 


### PR DESCRIPTION
A convenience method. Getting a single extension value is a pretty common task.