### PR TITLE
Added support for PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.4', '8.0']
+        php: ['7.4', '8.0', '8.1']
 
     steps:
       - name: Checkout Code

--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,14 @@
         }
     },
     "require": {
-        "php": ">=7.4",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "ext-pcre": "*",
         "symfony/polyfill-php80": "^1.17"
     },
     "require-dev": {
-        "nunomaduro/collision": "^5.2",
-        "phpunit/phpunit": "^9.5",
-        "squizlabs/php_codesniffer": "^3.5"
+        "phpunit/phpunit": "^9.5 || ^10.0",
+        "squizlabs/php_codesniffer": "^3.6"
     },
     "scripts": {
         "lint": "./vendor/bin/phpcs --standard=PSR12 ./src ./tests",
@@ -37,11 +36,13 @@
         "tests": "./vendor/bin/phpunit",
         "tests-build": [
             "DOCKER_BUILDKIT=1 docker build -t cloudevents/sdk-php:7.4-tests -f hack/7.4.Dockerfile hack",
-            "DOCKER_BUILDKIT=1 docker build -t cloudevents/sdk-php:8.0-tests -f hack/8.0.Dockerfile hack"
+            "DOCKER_BUILDKIT=1 docker build -t cloudevents/sdk-php:8.0-tests -f hack/8.0.Dockerfile hack",
+            "DOCKER_BUILDKIT=1 docker build -t cloudevents/sdk-php:8.1-tests -f hack/8.1.Dockerfile hack"
         ],
         "tests-docker": [
             "docker run -it -v $(pwd):/var/www cloudevents/sdk-php:7.4-tests --coverage-html=coverage",
-            "docker run -it -v $(pwd):/var/www cloudevents/sdk-php:8.0-tests"
+            "docker run -it -v $(pwd):/var/www cloudevents/sdk-php:8.0-tests",
+            "docker run -it -v $(pwd):/var/www cloudevents/sdk-php:8.1-tests"
         ]
     },
     "scripts-descriptions": {
@@ -52,11 +53,14 @@
         "tests-docker": "Run tests within supported PHP version containers"
     },
     "config": {
+        "preferred-install": "dist",
         "sort-packages": true
     },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/hack/8.1.Dockerfile
+++ b/hack/8.1.Dockerfile
@@ -1,11 +1,11 @@
-FROM php:8.0-alpine
+FROM php:8.1.0beta1-alpine
 
-LABEL org.opencontainers.image.url="https://github.com/cloudevents/sdk-php/tree/master/hack/8.0.Dockerfile" \
+LABEL org.opencontainers.image.url="https://github.com/cloudevents/sdk-php/tree/master/hack/8.1.Dockerfile" \
       org.opencontainers.image.documentation="https://github.com/cloudevents/sdk-php/tree/master/hack/README.md" \
       org.opencontainers.image.source="https://github.com/cloudevents/sdk-php" \
       org.opencontainers.image.vendor="CloudEvent" \
-      org.opencontainers.image.title="PHP 8.0" \
-      org.opencontainers.image.description="PHP 8.0 test environment for cloudevents/sdk-php"
+      org.opencontainers.image.title="PHP 8.1" \
+      org.opencontainers.image.description="PHP 8.1 test environment for cloudevents/sdk-php"
 
 COPY --chown=www-data:www-data install-composer /usr/local/bin/install-composer
 RUN chmod +x /usr/local/bin/install-composer \

--- a/hack/install-composer
+++ b/hack/install-composer
@@ -1,17 +1,6 @@
 #!/bin/sh
 
-EXPECTED_CHECKSUM="$(wget -q -O - https://composer.github.io/installer.sig)"
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
-
-if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]
-then
-    >&2 echo 'ERROR: Invalid installer checksum'
-    rm composer-setup.php
-    exit 1
-fi
-
+php -r "if (hash_file('sha384', 'composer-setup.php') === '756890a4488ce9024fc62c56153228907f1545c228516cbf63f885e036d37e9a59d27d63f46af1d4d07ee0f76181c7d3') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
 php composer-setup.php --install-dir=/usr/local/bin --filename=composer --quiet
-RESULT=$?
-rm composer-setup.php
-exit $RESULT
+php -r "unlink('composer-setup.php');" \

--- a/hack/install-composer-2.0.8
+++ b/hack/install-composer-2.0.8
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-php -r "if (hash_file('sha384', 'composer-setup.php') === '756890a4488ce9024fc62c56153228907f1545c228516cbf63f885e036d37e9a59d27d63f46af1d4d07ee0f76181c7d3') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
-php composer-setup.php --install-dir=/usr/local/bin --filename=composer --quiet
-php -r "unlink('composer-setup.php');" \

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,23 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
          bootstrap="vendor/autoload.php"
          cacheResultFile=".phpunit.cache/test-results"
          executionOrder="depends,defects"
-         forceCoversAnnotation="true"
-         beStrictAboutCoversAnnotation="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
          failOnRisky="true"
          failOnWarning="true"
-         printerClass="NunoMaduro\Collision\Adapters\Phpunit\Printer"
+         forceCoversAnnotation="true"
          verbose="true">
     <testsuites>
         <testsuite name="default">
             <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
-
     <coverage cacheDirectory=".phpunit.cache/code-coverage"
               processUncoveredFiles="true">
         <include>

--- a/tests/CloudEvents/Serializers/Formatters/FormatterTest.php
+++ b/tests/CloudEvents/Serializers/Formatters/FormatterTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 use ValueError;
 
 /**
- * @coversDefaultClass \CloudEvents\Serializers\Formmaters\Formatter
+ * @coversDefaultClass \CloudEvents\Serializers\Formatters\Formatter
  */
 class FormatterTest extends TestCase
 {


### PR DESCRIPTION
The feature freeze on PHP 8.1 has just passed, and PHP 8.1.0beta1 and Composer 2.1.5 has just been released (with full support for PHP 8.1). Now is the right time to start supporting PHP 8.1 and extending CI testing to cover it.