### PR TITLE
Use strpos() instead of str_contains() to retain PHP 7.4 compatibility

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '7.4'
           tools: composer:v2
           coverage: none
 

--- a/src/Utilities/TimeFormatter.php
+++ b/src/Utilities/TimeFormatter.php
@@ -35,7 +35,7 @@ final class TimeFormatter
         }
 
         $decoded = DateTimeImmutable::createFromFormat(
-            \str_contains($time, '.') ? self::RFC3339_EXTENDED_FORMAT : self::RFC3339_FORMAT,
+            \strpos($time, '.') !== false ? self::RFC3339_EXTENDED_FORMAT : self::RFC3339_FORMAT,
             \strtoupper($time),
             new DateTimeZone(self::TIME_ZONE)
         );


### PR DESCRIPTION
This is a small PR to retain compatibility with PHP 7.4 that was lost with the latest enhancements to TimeFormatter.