### PR TITLE
Fixed everything that broke after master was renamed to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ scripts:
 
 Each SDK may have its own unique processes, tooling and guidelines, common
 governance related material can be found in the
-[CloudEvents `community`](https://github.com/cloudevents/spec/tree/master/community)
+[CloudEvents `community`](https://github.com/cloudevents/spec#community-and-docs)
 directory. In particular, in there you will find information concerning
 how SDK projects are
-[managed](https://github.com/cloudevents/spec/blob/master/community/SDK-GOVERNANCE.md),
-[guidelines](https://github.com/cloudevents/spec/blob/master/community/SDK-maintainer-guidelines.md)
+[managed](https://github.com/cloudevents/spec/blob/main/docs/SDK-GOVERNANCE.md),
+[guidelines](https://github.com/cloudevents/spec/blob/main/docs/SDK-maintainer-guidelines.md)
 for how PR reviews and approval, and our
-[Code of Conduct](https://github.com/cloudevents/spec/blob/master/community/GOVERNANCE.md#additional-information)
+[Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
 information.

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-main": "1.0-dev"
         }
     },
     "minimum-stability": "dev",

--- a/hack/7.4.Dockerfile
+++ b/hack/7.4.Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.4-alpine
 
-LABEL org.opencontainers.image.url="https://github.com/cloudevents/sdk-php/tree/master/hack/7.4.Dockerfile" \
-      org.opencontainers.image.documentation="https://github.com/cloudevents/sdk-php/tree/master/hack/README.md" \
+LABEL org.opencontainers.image.url="https://github.com/cloudevents/sdk-php/tree/main/hack/7.4.Dockerfile" \
+      org.opencontainers.image.documentation="https://github.com/cloudevents/sdk-php/tree/main/hack/README.md" \
       org.opencontainers.image.source="https://github.com/cloudevents/sdk-php" \
       org.opencontainers.image.vendor="CloudEvent" \
       org.opencontainers.image.title="PHP 7.4" \

--- a/hack/8.0.Dockerfile
+++ b/hack/8.0.Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.0-alpine
 
-LABEL org.opencontainers.image.url="https://github.com/cloudevents/sdk-php/tree/master/hack/8.0.Dockerfile" \
-      org.opencontainers.image.documentation="https://github.com/cloudevents/sdk-php/tree/master/hack/README.md" \
+LABEL org.opencontainers.image.url="https://github.com/cloudevents/sdk-php/tree/main/hack/8.0.Dockerfile" \
+      org.opencontainers.image.documentation="https://github.com/cloudevents/sdk-php/tree/main/hack/README.md" \
       org.opencontainers.image.source="https://github.com/cloudevents/sdk-php" \
       org.opencontainers.image.vendor="CloudEvent" \
       org.opencontainers.image.title="PHP 8.0" \

--- a/hack/8.1.Dockerfile
+++ b/hack/8.1.Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.1-alpine
 
-LABEL org.opencontainers.image.url="https://github.com/cloudevents/sdk-php/tree/master/hack/8.1.Dockerfile" \
-      org.opencontainers.image.documentation="https://github.com/cloudevents/sdk-php/tree/master/hack/README.md" \
+LABEL org.opencontainers.image.url="https://github.com/cloudevents/sdk-php/tree/main/hack/8.1.Dockerfile" \
+      org.opencontainers.image.documentation="https://github.com/cloudevents/sdk-php/tree/main/hack/README.md" \
       org.opencontainers.image.source="https://github.com/cloudevents/sdk-php" \
       org.opencontainers.image.vendor="CloudEvent" \
       org.opencontainers.image.title="PHP 8.1" \


### PR DESCRIPTION
It looks like the master branch was renamed to main, but no care was taken to check impact. This has broken the ability to install 1.0-dev versions via composer, most notably.

---

* [x] ~Depends on https://github.com/cloudevents/sdk-php/pull/44.~