### PR TITLE
Enable configuration of sub-second precision of timestamps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,8 +48,8 @@
             "DOCKER_BUILDKIT=1 docker build -t cloudevents/sdk-php:7.4-tests -f hack/7.4.Dockerfile hack",
             "DOCKER_BUILDKIT=1 docker build -t cloudevents/sdk-php:8.0-tests -f hack/8.0.Dockerfile hack",
             "DOCKER_BUILDKIT=1 docker build -t cloudevents/sdk-php:8.1-tests -f hack/8.1.Dockerfile hack",
-            "DOCKER_BUILDKIT=1 docker build -t cloudevents/sdk-php:8.2-tests -f hack/8.1.Dockerfile hack",
-            "DOCKER_BUILDKIT=1 docker build -t cloudevents/sdk-php:8.3-tests -f hack/8.1.Dockerfile hack"
+            "DOCKER_BUILDKIT=1 docker build -t cloudevents/sdk-php:8.2-tests -f hack/8.2.Dockerfile hack",
+            "DOCKER_BUILDKIT=1 docker build -t cloudevents/sdk-php:8.3-tests -f hack/8.3.Dockerfile hack"
         ],
         "tests-docker": [
             "docker run -it -v $(pwd):/var/www cloudevents/sdk-php:7.4-tests --coverage-html=coverage",
@@ -76,7 +76,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.0-dev"
+            "dev-main": "1.1-dev"
         }
     },
     "minimum-stability": "dev",

--- a/src/Serializers/Normalizers/V1/Normalizer.php
+++ b/src/Serializers/Normalizers/V1/Normalizer.php
@@ -11,12 +11,25 @@ use CloudEvents\Utilities\DataFormatter;
 final class Normalizer implements NormalizerInterface
 {
     /**
+     * @var array{subsecondPrecision?: int<0, 6>}
+     */
+    private array $configuration;
+
+    /**
+     * @param array{subsecondPrecision?: int<0, 6>} $configuration
+     */
+    public function __construct(array $configuration = [])
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function normalize(CloudEventInterface $cloudEvent, bool $rawData): array
     {
         return array_merge(
-            AttributeConverter::toArray($cloudEvent),
+            AttributeConverter::toArray($cloudEvent, $this->configuration),
             DataFormatter::encode($cloudEvent->getData(), $rawData)
         );
     }

--- a/src/Utilities/AttributeConverter.php
+++ b/src/Utilities/AttributeConverter.php
@@ -13,9 +13,11 @@ use CloudEvents\V1\CloudEventInterface;
 final class AttributeConverter
 {
     /**
+     * @param array{subsecondPrecision?: int<0, 6>} $configuration
+     *
      * @return array<string, bool|int|string>
      */
-    public static function toArray(CloudEventInterface $cloudEvent): array
+    public static function toArray(CloudEventInterface $cloudEvent, array $configuration): array
     {
         /** @var array<string, bool|int|string> */
         $attributes = array_filter([
@@ -26,7 +28,7 @@ final class AttributeConverter
             'datacontenttype' => $cloudEvent->getDataContentType(),
             'dataschema' => $cloudEvent->getDataSchema(),
             'subject' => $cloudEvent->getSubject(),
-            'time' => TimeFormatter::encode($cloudEvent->getTime()),
+            'time' => TimeFormatter::encode($cloudEvent->getTime(), $configuration['subsecondPrecision'] ?? 0),
         ], fn ($attr) => $attr !== null);
 
         return array_merge($attributes, $cloudEvent->getExtensions());

--- a/tests/Unit/Serializers/Normalizers/V1/NormalizerTest.php
+++ b/tests/Unit/Serializers/Normalizers/V1/NormalizerTest.php
@@ -80,4 +80,40 @@ class NormalizerTest extends TestCase
             $formatter->normalize($event, false)
         );
     }
+
+    public function testNormalizerWithSubsecondPrecisionConfiguration(): void
+    {
+        /** @var CloudEventInterface|Stub $event */
+        $event = $this->createStub(CloudEventInterface::class);
+        $event->method('getSpecVersion')->willReturn('1.0');
+        $event->method('getId')->willReturn('1234-1234-1234');
+        $event->method('getSource')->willReturn('/var/data');
+        $event->method('getType')->willReturn('com.example.someevent');
+        $event->method('getDataContentType')->willReturn('application/json');
+        $event->method('getDataSchema')->willReturn('com.example/schema');
+        $event->method('getSubject')->willReturn('larger-context');
+        $event->method('getTime')->willReturn(new DateTimeImmutable('2018-04-05T17:31:00.123456Z'));
+        $event->method('getData')->willReturn(['key' => 'value']);
+        $event->method('getExtensions')->willReturn(['comacme' => 'foo']);
+
+        $formatter = new Normalizer(['subsecondPrecision' => 3]);
+
+        self::assertSame(
+            [
+                'specversion' => '1.0',
+                'id' => '1234-1234-1234',
+                'source' => '/var/data',
+                'type' => 'com.example.someevent',
+                'datacontenttype' => 'application/json',
+                'dataschema' => 'com.example/schema',
+                'subject' => 'larger-context',
+                'time' => '2018-04-05T17:31:00.123Z',
+                'comacme' => 'foo',
+                'data' => [
+                    'key' => 'value',
+                ],
+            ],
+            $formatter->normalize($event, false)
+        );
+    }
 }

--- a/tests/Unit/Utilities/TimeFormatterTest.php
+++ b/tests/Unit/Utilities/TimeFormatterTest.php
@@ -11,11 +11,27 @@ use ValueError;
 
 class TimeFormatterTest extends TestCase
 {
-    public function testEncode(): void
+    public static function providesValidEncodeCases(): array
+    {
+        return [
+            ['2018-04-05T17:31:00Z', '2018-04-05T17:31:00.123456Z', 0],
+            ['2018-04-05T17:31:00.1Z', '2018-04-05T17:31:00.123456Z', 1],
+            ['2018-04-05T17:31:00.12Z', '2018-04-05T17:31:00.123456Z', 2],
+            ['2018-04-05T17:31:00.123Z', '2018-04-05T17:31:00.123456Z', 3],
+            ['2018-04-05T17:31:00.1234Z', '2018-04-05T17:31:00.123456Z', 4],
+            ['2018-04-05T17:31:00.12345Z', '2018-04-05T17:31:00.123456Z', 5],
+            ['2018-04-05T17:31:00.123456Z', '2018-04-05T17:31:00.123456Z', 6],
+        ];
+    }
+
+    /**
+     * @dataProvider providesValidEncodeCases
+     */
+    public function testEncode(string $expected, string $input, int $subsecondPrecision): void
     {
         self::assertEquals(
-            '2018-04-05T17:31:00Z',
-            TimeFormatter::encode(new DateTimeImmutable('2018-04-05T17:31:00Z'))
+            $expected,
+            TimeFormatter::encode(new DateTimeImmutable($input), $subsecondPrecision)
         );
     }
 
@@ -83,7 +99,7 @@ class TimeFormatterTest extends TestCase
     {
         self::assertEquals(
             null,
-            TimeFormatter::encode(null)
+            TimeFormatter::encode(null, 0)
         );
     }
 


### PR DESCRIPTION
This PR enables the configuration of the sub-second precision in serialized timestamps. None of these changes are breaking because either the changes are made to classes marked as internal or a new constructor added to a final class with all parameters optional, and the default precision remains unchanged.

Example usage, serializing a cloudevent timestamp including the milliseconds but not the microseconds:

```php
$cloudEvent = (new CloudEvents\V1\CloudEventImmutable('a', 'b', 'c'))
    ->withTime(new DateTimeImmutable('2023-01-01T01:23:45.567890Z'));

$serializer = new CloudEvents\Serializers\JsonSerializer(
    new CloudEvents\Serializers\Normalizers\V1\Normalizer([
        'subsecondPrecision' => 3,
    ]),
);

// {"specversion":"1.0","id":"a","source":"b","type":"c","time":"2023-01-01T01:23:45.567Z"}
echo $serializer->serializeStructured($cloudEvent);
```

Note that on the deserialisation side of the house, we already can handle sub-second timestamps of any precision, truncating down to at most 6 digits, as supported by PHP, without any configuration.